### PR TITLE
Update sub-actions to node 20

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global init.defaultBranch "main"
 
     - name: Checkout global-tz
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: 'global-tz'
         fetch-depth: 0
@@ -62,7 +62,7 @@ jobs:
         ls -la
 
     - name: Publish artifacs to inspect manually
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Output global-tz files
         retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global init.defaultBranch "main"
 
     - name: Checkout global-tz
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: 'global-tz'
         fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
         ls -la
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         body: Release ${{ env.TAG_VERSION }} of global-tz, derived from iana-tz
         tag_name: ${{ env.TAG_VERSION }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,26 +22,26 @@ jobs:
         git config --global init.defaultBranch "main"
 
     - name: Checkout global-tz
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: 'main'
         fetch-depth: 0
 
     - name: Checkout global-tz
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: 'global'
         ref: 'global-tz'
         fetch-depth: 0
 
     - name: Checkout iana-tz
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'eggert/tz'
         path: 'iana'
         fetch-depth: 0
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'


### PR DESCRIPTION
Hopefully this will get rid of the node 16 warnings.

I have tested it - esp. given the breaking changes in actions/upload-artifact@v4, https://github.com/actions/upload-artifact/blob/main/README.md#breaking-changes. I don't think any of those changes are relevant here, and it still seems to behave as expected.

See the run https://github.com/tim-hitchins-ekkosense/global-tz/actions/runs/8270410655/job/22627863406 and the generated artefact at https://github.com/tim-hitchins-ekkosense/global-tz/actions/runs/8270410655/artifacts/1323631821